### PR TITLE
Enable audible autoplay gate on theKing page

### DIFF
--- a/static/css/theKing.css
+++ b/static/css/theKing.css
@@ -85,6 +85,27 @@ body {
   max-width: 100%;
 }
 
+#the-king-audio-gate {
+  position: absolute;
+  left: 50%;
+  bottom: 32px;
+  transform: translateX(-50%);
+  padding: 6px 12px;
+  background: rgba(0, 0, 0, 0.85);
+  color: #5fde5f;
+  font-family: var(--console-font);
+  font-size: 13px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid rgba(95, 222, 95, 0.6);
+  box-shadow: 0 0 0 1px rgba(0, 0, 0, 0.9) inset;
+  pointer-events: none;
+}
+
+#the-king-audio-gate[hidden] {
+  display: none;
+}
+
 #the-king-blur {
   background-image: url('/img/theKingBlur.jpg');
   width: 600px;


### PR DESCRIPTION
## Summary
- add a console-style audio gate prompt and consent persistence so theKing video can enable sound immediately after a gesture
- update autoplay logic to remember prior approval, retry unmuted playback, and clear activation handlers once audio starts
- style the unobtrusive prompt within the existing window without altering the rest of the layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d98edff56c832db95a52460a81a595