### PR TITLE
Add audio consent gate for the King video

### DIFF
--- a/static/css/theKing.css
+++ b/static/css/theKing.css
@@ -85,6 +85,29 @@ body {
   max-width: 100%;
 }
 
+#the-king-sound-gate {
+  position: absolute;
+  bottom: 42px;
+  left: 50%;
+  transform: translateX(-50%);
+  padding: 8px 14px;
+  background: rgba(0, 0, 0, 0.85);
+  border: 1px solid #5fde5f;
+  color: #5fde5f;
+  font-size: 14px;
+  letter-spacing: 0.05em;
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 150ms ease-in-out, visibility 150ms ease-in-out;
+  pointer-events: none;
+  white-space: nowrap;
+}
+
+#the-king-sound-gate.is-visible {
+  opacity: 1;
+  visibility: visible;
+}
+
 #the-king-blur {
   background-image: url('/img/theKingBlur.jpg');
   width: 600px;


### PR DESCRIPTION
## Summary
- add a minimal "sound gate" overlay for the King video that prompts users to unlock audio and saves consent in localStorage
- ensure autoplay starts muted, retries unmuted playback after the first gesture, and remembers consent for future visits
- style the prompt to match the console aesthetic and hide automatically once audio is unlocked

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68d98edff56c832db95a52460a81a595